### PR TITLE
Remove results layer on job start

### DIFF
--- a/javascript/src/reducers/layers.js
+++ b/javascript/src/reducers/layers.js
@@ -1,7 +1,7 @@
 import {morph} from '../utils'
 import {ADD_VARIABLE, REMOVE_VARIABLE} from "../actions/variables"
 import {TOGGLE_VISIBILITY} from "../actions/map"
-import {FINISH_JOB} from "../actions/job"
+import {FINISH_JOB, START_JOB} from "../actions/job"
 import {TOGGLE_LAYER, LOAD_TILES} from '../actions/layers'
 import config from 'seedsource/config'
 
@@ -63,6 +63,15 @@ export default (state = [], action) => {
             case TOGGLE_LAYER:
                 index = state.findIndex(layer => layer.name === action.name)
                 return state.slice(0, index).concat([morph(state[index], {displayed: !state[index].displayed}), ...state.slice(index+1)])
+            
+            case START_JOB:
+                let lastRunIndex = state.findIndex(layer => layer.name === 'Last Run')
+                if (lastRunIndex < 0) {
+                    return state
+                }
+                else {
+                    return state.slice(0, lastRunIndex).concat(state.slice(lastRunIndex+1))
+                }
 
             case FINISH_JOB:
                 let lastRun = state.find(layer => layer.name === "Last Run")


### PR DESCRIPTION
This PR fixes #22 regarding the results layer not updating. This fix removes the results layer when a new job is started, allowing it to be added back as usual when the job finishes. 