### PR TITLE
Add custom functions to reports

### DIFF
--- a/seedsource_core/django/seedsource/ppt.py
+++ b/seedsource_core/django/seedsource/ppt.py
@@ -193,7 +193,7 @@ class PPTCreator(object):
         for i, custom_function in enumerate(custom_functions, start=1):
             table.cell(i, 0).text = custom_function['name']
             table.cell(i, 1).text = custom_function['func']
-            table.cell(i, 2).text = str(round(custom_function['value'],2))
+            table.cell(i, 2).text = str(custom_function['value'])
             table.cell(i, 3).text = str(custom_function['transfer'])
 
     def create_constraints_slide(self, constraints):

--- a/seedsource_core/django/seedsource/ppt.py
+++ b/seedsource_core/django/seedsource/ppt.py
@@ -169,6 +169,33 @@ class PPTCreator(object):
             table.cell(i, 1).text = center_label
             table.cell(i, 2).text = limit_label
 
+    def create_custom_functions_slide(self, custom_functions):
+        slide = self.add_slide()
+        self.add_title_text(slide, _('Custom Functions'))
+
+        num_rows = len(custom_functions) + 1
+        table = slide.shapes.add_table(
+            num_rows, 4, Inches(.47), Inches(.73), Inches(9.05), Inches(.4) * num_rows
+        ).table
+
+        cols = table.columns
+        cols[0].width = Inches(2.1)
+        cols[1].width = Inches(3.75)
+        cols[2].width = Inches(0.6)
+        cols[2].width = Inches(0.9)
+
+        # Headers
+        table.cell(0, 0).text = _('Name')
+        table.cell(0, 1).text = _('Function')
+        table.cell(0, 2).text = _('Center')
+        table.cell(0, 3).text = _('Transfer limit') + ' (+/-)'
+
+        for i, custom_function in enumerate(custom_functions, start=1):
+            table.cell(i, 0).text = custom_function['name']
+            table.cell(i, 1).text = custom_function['func']
+            table.cell(i, 2).text = str(round(custom_function['value'],2))
+            table.cell(i, 3).text = str(custom_function['transfer'])
+
     def create_constraints_slide(self, constraints):
         slide = self.add_slide()
         self.add_title_text(slide, _('Constraints'))
@@ -348,6 +375,9 @@ class PPTCreator(object):
         ))
         self.create_overview_slide(context)
         self.create_variables_slide(context['variables'])
+
+        if context['custom_functions']:
+            self.create_custom_functions_slide(context['custom_functions'])
 
         if context['constraints']:
             self.create_constraints_slide(context['constraints'])

--- a/seedsource_core/django/seedsource/report.py
+++ b/seedsource_core/django/seedsource/report.py
@@ -248,6 +248,7 @@ class Report(object):
             'variables': self.get_context_variables(),
             'custom_mode': self.configuration['customMode'],
             'traits': self.get_context_traits(),
+            'custom_functions': self.configuration['customFunctions'],
             'constraints': self.get_context_constraints(),
             'title': SEEDSOURCE_TITLE
         }

--- a/seedsource_core/django/seedsource/report.py
+++ b/seedsource_core/django/seedsource/report.py
@@ -248,7 +248,7 @@ class Report(object):
             'variables': self.get_context_variables(),
             'custom_mode': self.configuration['customMode'],
             'traits': self.get_context_traits(),
-            'custom_functions': self.configuration['customFunctions'],
+            'custom_functions': [{ **cf, 'value': round(cf['value'], 2) } for cf in self.configuration['customFunctions']],
             'constraints': self.get_context_constraints(),
             'title': SEEDSOURCE_TITLE
         }

--- a/seedsource_core/django/seedsource/templates/pdf/report.html
+++ b/seedsource_core/django/seedsource/templates/pdf/report.html
@@ -214,7 +214,7 @@
         </div>
     {% endblock %}
 
-    {% if method == "seedzone" or method == "function" %}
+    {% if method == "seedzone" or method == "trait" %}
         <div>&nbsp;</div>
 
         {% block species %}<div><strong>{% trans "Species:" %}</strong> {{ species }}</div>{% endblock %}
@@ -230,7 +230,7 @@
         {% endif %}
     {% endif %}
 
-    {% if method == "function" %}
+    {% if method == "trait" %}
         {% block traits %}
             <h3>{% trans "Traits" %}</h3>
             <div>
@@ -251,6 +251,32 @@
                                     {{ trait.limit }} {{ trait.units|safe }}
                                     {% if trait.modified %}(modified{% endif %}
                                 </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endblock %}
+    {% elif method == "function" %}
+        {% block function %}
+            <h3>{% trans "Custom Functions" %}</h3>
+            <div>
+                <table class="variables">
+                    <thead>
+                        <tr>
+                            <th>{% trans "Name" %}</th>
+                            <th>{% trans "Function" %}</th>
+                            <th>{% trans "Center" %}</th>
+                            <th>{% trans "Transfer limit" %} (+/-)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for custom_function in custom_functions %}
+                            <tr>
+                                <td>{{ custom_function.name }}</td>
+                                <td>{{ custom_function.func }}</td>
+                                <td>{{ custom_function.value }}</td>
+                                <td>{{ custom_function.transfer }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
This PR adds custom functions to the PDF and PPT reports. There is also a small companion PR: https://github.com/consbio/seedsource-ui/pull/15. For the sake of simplicity I'll update SST and CSRT to the latest `seedsource-core` upon approval of this PR instead of making two more PR's.

Resolves SST-19, SST-20

The PDF:
<img width="497" alt="image" src="https://user-images.githubusercontent.com/20808982/199832970-2e0807ca-dfee-44f7-a314-0a3b0d38eb56.png">

The PPT slide:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/20808982/199832774-4d61e145-6354-4ad7-82f5-6ca66b1dfe93.png">